### PR TITLE
Change of call to Msm_predict in predict.msmmodel

### DIFF
--- a/R/Msm.R
+++ b/R/Msm.R
@@ -150,7 +150,7 @@ predict.msmmodel <- function(object, h=NULL,...){
     smoothed.p <- Msm_smooth_cpp(object$A,object$filtered)
   }
 
-  pred <- Msm_predict(object$g.m, object$para[4], object$n, smoothed.p, object$A, h)
+  pred <- Msm_predict(object$g.m, object$para[4]*sqrt(object$n), object$n, smoothed.p, object$A, h)
   return(pred)
 }
 


### PR DESCRIPTION
fix the call to Msm_predict so that it matches the commentary of Msm_predict else we divide two times by sqrt(n.vol) when giving passing the fit object like in the README.md